### PR TITLE
DOC: Fix typos in DSI and SHORE reconstruction files.

### DIFF
--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -30,7 +30,7 @@ class DiffusionSpectrumModel(OdfModel, Cache):
                 \end{eqnarray}
 
         where $\mathbf{r}$ is the displacement vector and $\mathbf{q}$ is the
-        wavector which corresponds to different gradient directions. Method
+        wave vector which corresponds to different gradient directions. Method
         used to calculate the ODFs. Here we implement the method proposed by
         Wedeen et. al [1]_.
 
@@ -511,7 +511,7 @@ class DiffusionSpectrumDeconvModel(DiffusionSpectrumModel):
                 \end{eqnarray*}
 
         where $\mathbf{r}$ is the displacement vector and $\mathbf{q}$ is the
-        wavector which corresponds to different gradient directions,
+        wave vector which corresponds to different gradient directions,
         $M(\mathbf{q})$ is a mask corresponding to your q-space sampling and
         $\otimes$ is the convolution operator [1]_.
 

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -178,7 +178,7 @@ class MapmriModel(ReconstModel, Cache):
 
         .. [2] Ozarslan E. et. al, "Simple harmonic oscillator based
                reconstruction and estimation for one-dimensional q-space
-               magnetic resonance 1D-SHORE)", eapoc Intl Soc Mag Reson Med,
+               magnetic resonance 1D-SHORE)", Proc Intl Soc Mag Reson Med,
                vol. 16, p. 35., 2008.
 
         .. [3] Ozarslan E. et. al, "Simple harmonic oscillator based

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -31,19 +31,19 @@ class ShoreModel(Cache):
                 S(\mathbf{q})= \sum_{i=0}^I  c_{i} \phi_{i}(\mathbf{q}).
             \end{equation}
 
-    where $\mathbf{q}$ is the wavector which corresponds to different gradient
-    directions. Numerous continuous functions $\phi_i$ can be used to model
-    $S$. Some are presented in [2,3,4]_.
+    where $\mathbf{q}$ is the wave vector which corresponds to different
+    gradient directions. Numerous continuous functions $\phi_i$ can be used to
+    model $S$. Some are presented in [2,3,4]_.
 
     From the $c_i$ coefficients, there exist analytical formulae to estimate
-    the ODF, the return to the origin porbability (RTOP), the mean square
+    the ODF, the return to the origin probability (RTOP), the mean square
     displacement (MSD), amongst others [5]_.
 
     References
     ----------
     .. [1] Ozarslan E. et. al, "Simple harmonic oscillator based reconstruction
            and estimation for one-dimensional q-space magnetic resonance
-           1D-SHORE)", eapoc Intl Soc Mag Reson Med, vol. 16, p. 35., 2008.
+           1D-SHORE)", Proc Intl Soc Mag Reson Med, vol. 16, p. 35., 2008.
 
     .. [2] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
            estimation via Compressive Sensing in diffusion MRI", Medical
@@ -52,7 +52,7 @@ class ShoreModel(Cache):
     .. [3] Rathi Y. et. al, "Sparse multi-shell diffusion imaging", MICCAI,
            2011.
 
-    .. [4] Cheng J. et. al, "Theoretical Analysis and eapactical Insights on
+    .. [4] Cheng J. et. al, "Theoretical Analysis and Practical Insights on
            EAP Estimation via a Unified HARDI Framework", MICCAI workshop on
            Computational Diffusion MRI, 2011.
 
@@ -93,7 +93,7 @@ class ShoreModel(Cache):
                     S(\mathbf{q})= \sum_{i=0}^I  c_{i} \phi_{i}(\mathbf{q}).
                 \end{equation}
 
-        where $\mathbf{q}$ is the wavector which corresponds to different
+        where $\mathbf{q}$ is the wave vector which corresponds to different
         gradient directions.
 
         From the $c_i$ coefficients, there exists an analytical formula to
@@ -137,7 +137,7 @@ class ShoreModel(Cache):
         ODF estimation via Compressive Sensing in diffusion MRI", Medical
         Image Analysis, 2013.
 
-        .. [2] Cheng J. et al., "Theoretical Analysis and eapactical Insights
+        .. [2] Cheng J. et al., "Theoretical Analysis and Practical Insights
         on EAP Estimation via a Unified HARDI Framework", MICCAI workshop on
         Computational Diffusion MRI, 2011.
 


### PR DESCRIPTION
Fix typos:
- Fix `wavector` : `wave vector`.
- Fix `eapactical` : `Practical` in reference `[4] Cheng J. et al.`.